### PR TITLE
Adding fields = __all__ to Meta of SiteAnnouncementModelForm

### DIFF
--- a/modal_announcements/admin.py
+++ b/modal_announcements/admin.py
@@ -22,6 +22,7 @@ class SiteAnnouncementModelForm(forms.ModelForm):
 
     class Meta:
         model = SiteAnnouncement
+        fields = '__all__'
 
     def clean_weekdays(self):
         weekdays = self.cleaned_data['weekdays']


### PR DESCRIPTION
Received the following error while trying to install:

```
django.core.exceptions.ImproperlyConfigured: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is prohibited; form SiteAnnouncementModelForm needs updating.
```

So just adding the fields attribute.
